### PR TITLE
Fix typo in SSL options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,7 +51,7 @@ rabbitmq_ssl_listeners: []
 # - 127.0.0.1
 # - "::1"
 
-rabitmq_ssl_options: {}
+rabbitmq_ssl_options: {}
 # cacertfile: '"/path/to/testca/cacert.pem"'
 # certfile: '"/path/to/server/cert.pem"'
 # keyfile: '"/path/to/server/key.pem"'


### PR DESCRIPTION
Typo in rabbitmq_ssl_options variable name which lead to the var not taken in account in the config file template